### PR TITLE
buddy boost button links to profile

### DIFF
--- a/app/views/shared/_navbar.html.erb
+++ b/app/views/shared/_navbar.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg navbar-light bg-light px-3">
   <div class="container-fluid">
     <a class="navbar-brand" href="/"><i class="fa-solid fa-user-group"></i></a>
-    <a class="navbar-brand" href="/">BuddyBoost</a>
+    <a class="navbar-brand" href="/profile">BuddyBoost</a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse"
             data-bs-target="#navbarNav" aria-controls="navbarNav"
             aria-expanded="false" aria-label="Toggle navigation">


### PR DESCRIPTION
this button now links to profile when logged in and to log-in page when signed out

<img width="248" alt="image" src="https://github.com/karanse/buddy-boost/assets/156322797/a46ad2a0-c2a7-4f7d-b282-1de3e16cc47b">

had to create a new pull request because the other one was weird 😩 